### PR TITLE
Fix unresolved symbol when linking statically

### DIFF
--- a/project/common/ExternalInterface.cpp
+++ b/project/common/ExternalInterface.cpp
@@ -1019,8 +1019,13 @@ extern "C" {
 	}
 }
 
-extern "C" int openfl_webm_register_prims () {
+extern "C" int extension_webm_register_prims () {
 	
 	return 0;
 	
+}
+
+// DEPRECATED: Use extension_webm_register_prims instead.
+extern "C" int openfl_webm_register_prims () {
+	return extension_webm_register_prims();
 }


### PR DESCRIPTION
When linking a Lime program statically using the `-static` command line option, Lime's generated `main` function looks for a function named `extension_webm_register_prims`. Prior to this commit, this function was called `openfl_webm_register_prims`, causing a linker error.

This commit renames this function to `extension_webm_register_prims` and adds an `openfl_webm_register_prims` wrapper function for backwards compatibility just in case someone relied on the old function name.